### PR TITLE
Add Address Balances to originality exceptions

### DIFF
--- a/terminology/KEEP_ORIGINALITY.md
+++ b/terminology/KEEP_ORIGINALITY.md
@@ -33,6 +33,8 @@
 - ability
 - Agora Finance
 - adaptive concurrency
+- Address Balances
+- Address Balances Move API
 - availableRange
 - API
 - Awesome Sui
@@ -247,6 +249,7 @@
 - single sign-on (SSO)
 - single-owner fastpath
 - Snagit
+- Sui Address Balances
 - Sui Bridge
 - Sui CLI
 - Sui Client CLI

--- a/terminology/TRANSLATED_TERMINOLOGY.md
+++ b/terminology/TRANSLATED_TERMINOLOGY.md
@@ -29,11 +29,13 @@
 - address alias → 주소 별칭
 - address aliases → 주소 별칭
 - address balance → 주소 잔액
+  - 예외: SIP-58의 정식 기술명 또는 대문자 표기 `Address Balances`, `Sui Address Balances`의 일부일 때는 원문 유지
 - address balances → 주소 잔액
+  - 예외: SIP-58의 정식 기술명 또는 대문자 표기 `Address Balances`, `Sui Address Balances`의 일부일 때는 원문 유지
 - address-owned → 주소 소유
 - address-owned object → 주소 소유 객체
 - addresses → 주소
-- Address Balances Migration Guide → 주소 잔액 마이그레이션 가이드
+- Address Balances Migration Guide → Address Balances 마이그레이션 가이드
   - 유형: title-sync only
 - Accessing Data → 데이터 접근
 - action → 액션


### PR DESCRIPTION
Add 'Address Balances', 'Address Balances Move API', and 'Sui Address Balances' to KEEP_ORIGINALITY.md so these terms are preserved in source. Update TRANSLATED_TERMINOLOGY.md to add exceptions that keep the original capitalization for 'Address Balances' and 'Sui Address Balances' when they appear as SIP-58 official names or in uppercase-style titles, and change the translation for 'Address Balances Migration Guide' to keep the original title. These changes ensure SIP-58 technical names are not incorrectly translated.